### PR TITLE
Update bundle-ersd-supplemental-example.xml

### DIFF
--- a/input/resources/bundle/bundle-ersd-supplemental-example.xml
+++ b/input/resources/bundle/bundle-ersd-supplemental-example.xml
@@ -1183,7 +1183,7 @@
                 <property>
                     <code value="postalcode" />
                     <description value="Postal code within the public health jurisdiction." />
-                    <type value="string" />
+                    <type value="code" />
                 </property>
                 <concept>
                     <code value="AK" />


### PR DESCRIPTION
property is marked string but all the values are code type